### PR TITLE
Fixes #4

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--color

--- a/spec/cassettes/Vigor_Client/can_find_a_summoner_by_id.yml
+++ b/spec/cassettes/Vigor_Client/can_find_a_summoner_by_id.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://prod.api.pvp.net/api/lol/na/v1.1/summoner/23893133?api_key=<API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 12 Dec 2013 10:36:46 GMT
+      Server:
+      - Jetty(9.1.0.v20131115)
+      X-Newrelic-App-Data:
+      - PxQFWFFSDwQTVVdUBAgAVkYdFGQHBDcQUQxLA1tMXV1dORYzVBJHNQFUZAQUFVFQVThOA0dYa0kIXlpvTR0RB1cLVwxFZBtEAksIPR4SRg8JWVkEFD8XSEMRDA9YX1IULVVLE0ohJjYZQBRSFggYAh1VCVAIWARWVwEbTFdPGldRAFJTUwJTXlVTB1BXVQZAbQ==
+      Content-Length:
+      - '143'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":23893133,"name":"Semiel","profileIconId":518,"summonerLevel":30,"revisionDate":1386532311000,"revisionDateStr":"12/08/2013
+        07:51 PM UTC"}'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2013 10:36:31 GMT
+recorded_with: VCR 2.8.0

--- a/spec/cassettes/Vigor_Client/can_find_a_summoner_by_name.yml
+++ b/spec/cassettes/Vigor_Client/can_find_a_summoner_by_name.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://prod.api.pvp.net/api/lol/na/v1.1/summoner/by-name/semiel?api_key=<API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 12 Dec 2013 10:36:46 GMT
+      Server:
+      - Jetty(9.1.0.v20131115)
+      X-Newrelic-App-Data:
+      - PxQFWFFSDwQTVVdUBAgAVkYdFGQHBDcQUQxLA1tMXV1dORYzVBJHNQFUZAQUFVFQVThOA0dYa0kIXlpvTR0RB1cLVwxFZBtEAksIPR4SRg8JWVkEFD8XUUlJDwNaVGtJH19XXgcbQ0p3J2xLGhQEHANJCU8BUQJbVA4OUEpOCR8SVlcGA1VRVAcGBwtRXgcAUkBl
+      Content-Length:
+      - '143'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":23893133,"name":"Semiel","profileIconId":518,"summonerLevel":30,"revisionDate":1386532311000,"revisionDateStr":"12/08/2013
+        07:51 PM UTC"}'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2013 10:36:31 GMT
+recorded_with: VCR 2.8.0

--- a/spec/cassettes/Vigor_Client/can_find_summoners_whose_names_have_whitespace.yml
+++ b/spec/cassettes/Vigor_Client/can_find_summoners_whose_names_have_whitespace.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://prod.api.pvp.net/api/lol/na/v1.1/summoner/by-name/BestRivenNA?api_key=<API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 12 Dec 2013 10:36:47 GMT
+      Server:
+      - Jetty(9.1.0.v20131115)
+      X-Newrelic-App-Data:
+      - PxQFWFFSDwQTVVdUBAgAVkYdFGQHBDcQUQxLA1tMXV1dORYzVBJHNQFUZAQUFVFQVThOA0dYa0kIXlpvTR0RB1cLVwxFZBtEAksIPR4SRg8JWVkEFD8XUUlJDwNaVGtJH19XXgcbQ0p3J2xLGhQEHANJCU8BUQBRVgQAVlJPFQIcRgIAAFJTAAJQAQdRBAZXAgEaPw==
+      Content-Length:
+      - '150'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":32400810,"name":"Best Riven NA","profileIconId":508,"summonerLevel":30,"revisionDate":1386729379000,"revisionDateStr":"12/11/2013
+        02:36 AM UTC"}'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2013 10:36:31 GMT
+recorded_with: VCR 2.8.0

--- a/spec/cassettes/Vigor_Client/works_on_servers_other_than_NA.yml
+++ b/spec/cassettes/Vigor_Client/works_on_servers_other_than_NA.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://prod.api.pvp.net/api/lol/euw/v1.1/summoner/by-name/Froggen?api_key=<API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 12 Dec 2013 10:36:46 GMT
+      Server:
+      - Jetty(9.1.0.v20131115)
+      X-Newrelic-App-Data:
+      - PxQFWFFSDwQTVVdUBAgPUkYdFGQHBDcQUQxLA1tMXV1dORYzVBJHNQFUZAQUFVFQVThOA0dYa0kIXlpvTR0RB1cLVwxFZBtEAksIPR4SRg8JWVkEFD8XUUlJDwNaVGtJH19XXgcbQ0p3J2xLGhQEHANJCU8BUQBQVwAOWUpOCR8SUlNTAQVSVVUHDlFQVFoAVUBl
+      Content-Length:
+      - '144'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":19531813,"name":"Froggen","profileIconId":562,"summonerLevel":30,"revisionDate":1386782571000,"revisionDateStr":"12/11/2013
+        05:22 PM UTC"}'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2013 10:36:31 GMT
+recorded_with: VCR 2.8.0

--- a/spec/cassettes/Vigor_Summoner/can_fetch_masteries.yml
+++ b/spec/cassettes/Vigor_Summoner/can_fetch_masteries.yml
@@ -1,0 +1,92 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://prod.api.pvp.net/api/lol/na/v1.1/summoner/by-name/semiel?api_key=<API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 12 Dec 2013 10:34:37 GMT
+      Server:
+      - Jetty(9.1.0.v20131115)
+      X-Newrelic-App-Data:
+      - PxQFWFFSDwQTVVdUBAgAVkYdFGQHBDcQUQxLA1tMXV1dORYzVBJHNQFUZAQUFVFQVThOA0dYa0kIXlpvTR0RB1cLVwxFZBtEAksIPR4SRg8JWVkEFD8XUUlJDwNaVGtJH19XXgcbQ0p3J2xLGhQEHANJCU8BUQBQUQICV0pOCR8SVlcGUVdUXwdXAQoEUFBXEj8=
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":23893133,"name":"Semiel","profileIconId":518,"summonerLevel":30,"revisionDate":1386532311000,"revisionDateStr":"12/08/2013
+        07:51 PM UTC"}'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2013 10:34:21 GMT
+- request:
+    method: get
+    uri: http://prod.api.pvp.net/api/lol/na/v1.1/summoner/23893133/masteries?api_key=<API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, PUT
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 12 Dec 2013 10:34:37 GMT
+      Server:
+      - Jetty(9.1.0.v20131115)
+      X-Newrelic-App-Data:
+      - PxQFWFFSDwQTVVdUBAgAVkYdFGQHBDcQUQxLA1tMXV1dORYzVBJHNQFUZAQUFVFQVThOA0dYa0kIXlpvTR0RB1cLVwxFZBtEAksIPR4SRg8JWVkEFD8XSEMRDA9YX1IULVVLb00LAhFEB0oLXUsUGnQgbUgTTQNMVBoHT1ZVDAoAXFhbGxwGSkYABlBaA1FaB1cNUA5aAAMKR2Q=
+      Content-Length:
+      - '2757'
+      Connection:
+      - keep-alive
+    body:
+      encoding: US-ASCII
+      string: ! '{"summonerId":23893133,"pages":[{"name":"Mastery Page 4","current":false,"talents":[{"id":4233,"name":"Hardiness","rank":3},{"id":4211,"name":"Block","rank":2},{"id":4121,"name":"Expose
+        Weakness","rank":1},{"id":4213,"name":"Enchanted Armor","rank":2},{"id":4244,"name":"Evasive","rank":1},{"id":4234,"name":"Resistance","rank":3},{"id":4222,"name":"Veteran
+        Scars","rank":3},{"id":4113,"name":"Sorcery","rank":4},{"id":4221,"name":"Unyielding","rank":1},{"id":4252,"name":"Tenacious","rank":4},{"id":4123,"name":"Mental
+        Force","rank":3},{"id":4262,"name":"Legendary Guardian","rank":1},{"id":4133,"name":"Arcane
+        Mastery","rank":1},{"id":4232,"name":"Juggernaut","rank":1}]},{"name":"Mastery
+        Page 1","current":false,"talents":[{"id":4212,"name":"Recovery","rank":2},{"id":4242,"name":"Swiftness","rank":1},{"id":4213,"name":"Enchanted
+        Armor","rank":2},{"id":4211,"name":"Block","rank":1},{"id":4244,"name":"Evasive","rank":1},{"id":4333,"name":"Vampirism","rank":1},{"id":4234,"name":"Resistance","rank":3},{"id":4322,"name":"Summoner''s
+        Insight","rank":1},{"id":4323,"name":"Strength of Spirit","rank":1},{"id":4222,"name":"Veteran
+        Scars","rank":3},{"id":4252,"name":"Tenacious","rank":4},{"id":4262,"name":"Legendary
+        Guardian","rank":1},{"id":4312,"name":"Fleet of Foot","rank":3},{"id":4313,"name":"Meditation","rank":3},{"id":4232,"name":"Juggernaut","rank":1},{"id":4233,"name":"Hardiness","rank":2}]},{"name":"Mastery
+        Page 2","current":false,"talents":[{"id":4212,"name":"Recovery","rank":2},{"id":4211,"name":"Block","rank":2},{"id":4121,"name":"Expose
+        Weakness","rank":1},{"id":4134,"name":"Executioner","rank":3},{"id":4154,"name":"Arcane
+        Blade","rank":1},{"id":4222,"name":"Veteran Scars","rank":3},{"id":4113,"name":"Sorcery","rank":4},{"id":4221,"name":"Unyielding","rank":1},{"id":4144,"name":"Dangerous
+        Game","rank":1},{"id":4152,"name":"Devastating Strikes","rank":3},{"id":4123,"name":"Mental
+        Force","rank":3},{"id":4133,"name":"Arcane Mastery","rank":1},{"id":4143,"name":"Archmage","rank":3},{"id":4232,"name":"Juggernaut","rank":1},{"id":4162,"name":"Havoc","rank":1}]},{"name":"AP","current":true,"talents":[{"id":4212,"name":"Recovery","rank":2},{"id":4211,"name":"Block","rank":2},{"id":4121,"name":"Expose
+        Weakness","rank":1},{"id":4134,"name":"Executioner","rank":3},{"id":4154,"name":"Arcane
+        Blade","rank":1},{"id":4222,"name":"Veteran Scars","rank":3},{"id":4113,"name":"Sorcery","rank":4},{"id":4221,"name":"Unyielding","rank":1},{"id":4144,"name":"Dangerous
+        Game","rank":1},{"id":4152,"name":"Devastating Strikes","rank":3},{"id":4123,"name":"Mental
+        Force","rank":3},{"id":4133,"name":"Arcane Mastery","rank":1},{"id":4143,"name":"Archmage","rank":3},{"id":4232,"name":"Juggernaut","rank":1},{"id":4162,"name":"Havoc","rank":1}]}]}'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2013 10:34:21 GMT
+recorded_with: VCR 2.8.0

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,6 +1,4 @@
-require 'vigor'
-
-describe Vigor::Client do
+describe Vigor::Client, :vcr do
   it "can find a summoner by name" do
     vigor = Vigor::Client.new(ENV["API_KEY"])
     summoner = vigor.summoner("semiel")

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -30,6 +30,6 @@ describe Vigor::Client, :vcr do
     summoner = vigor.summoner("Best Riven NA")
     summoner.id.should == 32400810
     summoner.name.should == "Best Riven NA"
-    summoner.level == 30
+    summoner.level.should == 30
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+require 'vigor'
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/cassettes'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+  c.filter_sensitive_data("<API_KEY>") { ENV['API_KEY'] }
+end
+
+RSpec.configure do |c|
+  c.treat_symbols_as_metadata_keys_with_true_values = true
+end

--- a/spec/summoner_spec.rb
+++ b/spec/summoner_spec.rb
@@ -1,6 +1,4 @@
-require 'vigor'
-
-describe Vigor::Summoner do
+describe Vigor::Summoner, :vcr do
   it "can fetch masteries" do
     vigor = Vigor::Client.new(ENV["API_KEY"])
     summoner = vigor.summoner("semiel")

--- a/vigor.gemspec
+++ b/vigor.gemspec
@@ -12,4 +12,5 @@ Gem::Specification.new do |s|
   s.test_files  = Dir.glob('spec/')
   s.add_runtime_dependency 'httparty'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'vcr'
 end


### PR DESCRIPTION
Added vcr and configured rspec for it.

`spec_helper.rb` will be required for any spec file now (set in `.rspec`), so you can use that for any general test configuration.

It's configured to filter out `ENV['API_KEY']`, so that won't be saved in the cassettes (nor will it throw an error for a uri mismatch).
