### PR TITLE
defining respond_to_missing? in summoner

### DIFF
--- a/lib/vigor/summoner.rb
+++ b/lib/vigor/summoner.rb
@@ -61,5 +61,9 @@ class Vigor
       add_summoner_data(Client.get("/summoner/" + @id.to_s)) unless @fields[field]
       @fields[field]
     end
+
+    def respond_to_missing?(meth, *)
+      (Available_fields + @fields.keys).include?(meth) || super
+    end
   end
 end


### PR DESCRIPTION
Nice use of `method_missing`.

It's generally good practice to define `respond_to_missing` when doing that.
